### PR TITLE
Drupal 9 compatibility

### DIFF
--- a/elasticsearch_helper_index_alias.info.yml
+++ b/elasticsearch_helper_index_alias.info.yml
@@ -1,6 +1,7 @@
 name: Elasticsearch Helper Index Alias
 type: module
 description: A module which adds index versioning and alias features
+core_version_requirement: ^8 || ^9
 core: 8.x
 dependencies:
   - elasticsearch_helper


### PR DESCRIPTION
This PR adds Drupal 9 readiness for elasticsearch_helper_index_alias module.

Note:
Marking core_version_requirement: ^8 || ^9 as there is no deprecations introduced after 8.0.x

Checked with [Upgrade status](https://www.drupal.org/project/upgrade_status)