### PR TITLE
Updated static local tasks as secondary tabs

### DIFF
--- a/elasticsearch_helper_index_alias.links.task.yml
+++ b/elasticsearch_helper_index_alias.links.task.yml
@@ -1,14 +1,17 @@
-elasticsearch_helper_index_alias.controller.configure:
+elasticsearch_helper_index_alias.controller.index_management:
   route_name: elasticsearch_helper_index_management.index_list_controller_display
-  base_route: elasticsearch_helper_index_management.index_list_controller_display
+  parent_id: elasticsearch_helper_index_management.index_list_controller_display
   title: 'Index Management'
+  weight: 1
 
 elasticsearch_helper_index_alias.controller.aliases:
   route_name: elasticsearch_helper_index_alias.manage_alias_controller.aliases
-  base_route: elasticsearch_helper_index_management.index_list_controller_display
+  parent_id: elasticsearch_helper_index_management.index_list_controller_display
   title: 'Aliases Management'
+  weight: 2
 
 elasticsearch_helper_index_alias.controller.indices_status:
   route_name: elasticsearch_helper_index_alias.manage_alias_controller.indices_status
-  base_route: elasticsearch_helper_index_management.index_list_controller_display
-  title: 'Indices status'
+  parent_id: elasticsearch_helper_index_management.index_list_controller_display
+  title: 'Indices Status'
+  weight: 3


### PR DESCRIPTION
This PR updates static local tasks as secondary tabs under Index Managent tab grouped under Elasticearch Helper settings page.